### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/science_rcn/inference.py
+++ b/science_rcn/inference.py
@@ -17,6 +17,11 @@ from science_rcn.preproc import Preproc
 
 LOG = logging.getLogger(__name__)
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class RCNInferenceError(Exception):
     """Raise for general errors in RCN inference."""

--- a/science_rcn/preproc.py
+++ b/science_rcn/preproc.py
@@ -8,6 +8,11 @@ from scipy.signal import fftconvolve
 
 LOG = logging.getLogger(__name__)
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class Preproc(object):
     """

--- a/science_rcn/run.py
+++ b/science_rcn/run.py
@@ -14,6 +14,7 @@ python science_rcn/run.py --train_size 100 --test_size 20 --parallel
 (could take hours depending on the number of available CPUs, average accuracy is ~97.7+%):
 python science_rcn/run.py --full_test_set --train_size 1000 --parallel --pool_shape 25 --perturb_factor 2.0
 """
+from __future__ import print_function
 
 import argparse
 import logging
@@ -92,7 +93,7 @@ def run_experiment(data_dir='data/MNIST',
     correct = 0
     for test_idx, (winner_idx, _) in enumerate(test_results):
         correct += int(test_data[test_idx][1]) == winner_idx // (train_size // 10)
-    print "Total test accuracy = {}".format(float(correct) / len(test_results))
+    print("Total test accuracy = {}".format(float(correct) / len(test_results)))
 
     return all_model_factors, test_results
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
@@ -24,7 +25,7 @@ requirements = _findRequirements()
 # Check for MNIST data dir
 if not os.path.isdir('./data/MNIST'):
     if os.path.exists('./data/MNIST.zip'):
-        print "Extracting MNIST data..."
+        print("Extracting MNIST data...")
         with zipfile.ZipFile('./data/MNIST.zip', 'r') as z:
             z.extractall('./data/')
     else:


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. More work _might_ be required to complete the port to Python 3 but this is a minimal, safe first step.

* [futurize stage 1](http://python-future.org/futurize_cheatsheet.html#step-1-modern-py2-code)
* Defined xrange() == range() in Python 3 only.